### PR TITLE
Lexer/Preprocessor Errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,22 @@
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::lexer::lexer::Location;
+use crate::lexer::source::FileId;
+
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub message: String,
+    pub span: (Option<FileId>, Location, Location),
+}
+
+impl Error {
+    pub fn new(span: (Option<FileId>, Location, Location), message: String) -> Self {
+        Self {
+            span,
+            message,
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,12 @@ use crate::lexer::lexer::Location;
 use crate::lexer::source::FileId;
 use crate::lexer::errors::LexerError;
 
-pub type Span = (Option<FileId>, Location, Location);
+#[derive(Debug, Clone, Copy)]
+pub struct Span {
+    pub file: Option<FileId>,
+    pub start: Location,
+    pub end: Location,
+}
 
 #[derive(Debug, Clone)]
 pub enum Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,30 +5,25 @@
 
 use crate::lexer::lexer::Location;
 use crate::lexer::source::FileId;
+use crate::lexer::errors::LexerError;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompilerPhase {
-    Lexer,
-    Parser,
-}
+pub type Span = (Option<FileId>, Location, Location);
 
 #[derive(Debug, Clone)]
-pub struct Error {
-    pub phase: CompilerPhase,
-    pub message: String,
-    pub span: (Option<FileId>, Location, Location),
+pub enum Error {
+    LexerError(LexerError),
 }
 
 impl Error {
-    pub fn new(
-        phase: CompilerPhase,
-        span: (Option<FileId>, Location, Location),
-        message: String,
-    ) -> Self {
-        Self {
-            phase,
-            span,
-            message,
-        }
+    pub fn stringly(&self) -> StringlyError {
+        let stringly = match self {
+            Error::LexerError(le) => le.stringly(),
+        };
+        stringly
     }
+}
+
+pub struct StringlyError {
+    pub message: String,
+    pub sp: Span,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,15 +6,27 @@
 use crate::lexer::lexer::Location;
 use crate::lexer::source::FileId;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerPhase {
+    Lexer,
+    Parser,
+}
+
 #[derive(Debug, Clone)]
 pub struct Error {
+    pub phase: CompilerPhase,
     pub message: String,
     pub span: (Option<FileId>, Location, Location),
 }
 
 impl Error {
-    pub fn new(span: (Option<FileId>, Location, Location), message: String) -> Self {
+    pub fn new(
+        phase: CompilerPhase,
+        span: (Option<FileId>, Location, Location),
+        message: String,
+    ) -> Self {
         Self {
+            phase,
             span,
             message,
         }

--- a/src/lexer/errors.rs
+++ b/src/lexer/errors.rs
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::errors::{Span, StringlyError};
+
+#[derive(Clone, Debug)]
+pub enum LexerError {
+    ErrorDirective { sp: Span, msg: String, },
+    EndifWithoutPreceedingIf { sp: Span, },
+}
+
+impl LexerError {
+    pub fn stringly(&self) -> StringlyError {
+        use self::LexerError::*;
+        let (sp, message) = match self {
+            ErrorDirective { sp, msg, } => (*sp, format!("reached #error directive: {}", msg)),
+            EndifWithoutPreceedingIf { sp } => (*sp, "reached #endif without preceeding #if".to_owned()),
+        };
+        StringlyError {
+            message,
+            sp,
+        }
+    }
+}

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -15,6 +15,7 @@ use super::preprocessor::include::PathIndex;
 use super::source::{FileId, SourceMutex};
 use super::string::StringType;
 use super::errors::LexerError;
+use crate::errors::Span;
 use crate::args;
 
 #[derive(PartialEq)]
@@ -1028,8 +1029,12 @@ impl<'a, PC: PreprocContext> Lexer<'a, PC> {
         }
     }
 
-    pub(super) fn span(&self) -> (Option<FileId>, Location, Location) {
-        (self.buf.get_source_id(), self.start, self.location())
+    pub(super) fn span(&self) -> Span {
+        Span {
+            file: self.buf.get_source_id(),
+            start: self.start,
+            end: self.location(),
+        }
     }
 
     pub fn next_token(&mut self) -> Token {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -14,7 +14,7 @@ use super::preprocessor::context::PreprocContext;
 use super::preprocessor::include::PathIndex;
 use super::source::{FileId, SourceMutex};
 use super::string::StringType;
-use crate::errors::Error;
+use super::errors::LexerError;
 use crate::args;
 
 #[derive(PartialEq)]
@@ -508,7 +508,7 @@ pub struct Lexer<'a, PC: PreprocContext> {
     pub(crate) context: PC,
     pub(crate) comment: Option<&'a [u8]>,
     pub(crate) start: Location,
-    pub(crate) errors: Vec<Error>,
+    pub(crate) errors: Vec<LexerError>,
 }
 
 macro_rules! get_operator {
@@ -652,7 +652,7 @@ impl<'a, PC: PreprocContext> Lexer<'a, PC> {
         &self.context
     }
 
-    pub fn get_errors(&self) -> &[Error] {
+    pub fn get_errors(&self) -> &[LexerError] {
         &self.errors
     }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -3,6 +3,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#[macro_export]
+macro_rules! error {
+    ($span:expr, $($arg:tt)*) => {
+        return Err($crate::errors::Error::new(
+            $crate::errors::CompilerPhase::Lexer,
+            $span,
+            format!($($arg)*),
+        ));
+    };
+}
+
 pub mod lexer;
 pub use self::lexer::*;
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -3,22 +3,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[macro_export]
-macro_rules! error {
-    ($span:expr, $($arg:tt)*) => {
-        return Err($crate::errors::Error::new(
-            $crate::errors::CompilerPhase::Lexer,
-            $span,
-            format!($($arg)*),
-        ));
-    };
-}
-
 pub mod lexer;
 pub use self::lexer::*;
 
 pub mod preprocessor;
 pub mod source;
+
+pub mod errors;
 
 mod buffer;
 mod cchar;

--- a/src/lexer/preprocessor/preprocessor.rs
+++ b/src/lexer/preprocessor/preprocessor.rs
@@ -167,9 +167,21 @@ impl<'a, PC: PreprocContext> Lexer<'a, PC> {
                 Token::PreprocPragma
             }
             Token::PreprocError => {
-                skip_until!(self, b'\n');
-                self.buf.add_new_line();
-                Token::PreprocError
+                let mut buf = Vec::new();
+                loop {
+                    if self.buf.has_char() {
+                        let c = self.buf.next_char();
+                        if c == b'\n' {
+                            break;
+                        }
+                        buf.push(c);
+                        self.buf.inc();
+                    } else {
+                        break;
+                    }
+                };
+                let msg = String::from_utf8_lossy(&buf);
+                error!(self.span(), "reached #error directive: {}", msg);
             }
             _ => instr,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,4 @@ pub mod args;
 pub mod defaults;
 pub mod lexer;
 pub mod parser;
+pub mod errors;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -185,13 +185,3 @@ macro_rules! bitflags_to_str {
             v.join(" | ")
     }};
 }
-
-#[macro_export]
-macro_rules! error {
-    ($span:expr, $($arg:tt)*) => {
-        return Err($crate::errors::Error::new(
-            $span,
-            format!($($arg)*),
-        ));
-    };
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -185,3 +185,13 @@ macro_rules! bitflags_to_str {
             v.join(" | ")
     }};
 }
+
+#[macro_export]
+macro_rules! error {
+    ($span:expr, $($arg:tt)*) => {
+        return Err($crate::errors::Error::new(
+            $span,
+            format!($($arg)*),
+        ));
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,13 @@ fn main() {
     {
         let source_lock = source.lock().unwrap();
         for error in lexer.get_errors().iter() {
-            let file_path = if let Some(file) = error.span.0 {
+            let error = error.stringly();
+            let file_path = if let Some(file) = error.sp.0 {
                 source_lock.get_path(file).to_str().unwrap().to_owned()
             } else {
                 "<unknown>".to_owned()
             };
-            eprintln!("ERROR: {}:{}:{}: {}", file_path, error.span.1.line, error.span.1.column, error.message);
+            eprintln!("ERROR: {}:{}:{}: {}", file_path, error.sp.1.line, error.sp.1.column, error.message);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,12 @@ fn main() {
         let source_lock = source.lock().unwrap();
         for error in lexer.get_errors().iter() {
             let error = error.stringly();
-            let file_path = if let Some(file) = error.sp.0 {
+            let file_path = if let Some(file) = error.sp.file {
                 source_lock.get_path(file).to_str().unwrap().to_owned()
             } else {
                 "<unknown>".to_owned()
             };
-            eprintln!("ERROR: {}:{}:{}: {}", file_path, error.sp.1.line, error.sp.1.column, error.message);
+            eprintln!("ERROR: {}:{}:{}: {}", file_path, error.sp.start.line, error.sp.start.column, error.message);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,23 @@ fn main() {
         includes: Vec::new(),
         current_dir: PathBuf::from("."),
     };
-    let mut lexer = Lexer::<DefaultContext>::new_from_file(file.to_str().unwrap(), source, opt);
+    let mut lexer = Lexer::<DefaultContext>::new_from_file(file.to_str().unwrap(), source.clone(), opt);
     loop {
         let tok = lexer.next_token();
         eprintln!("TOK: {:?}", tok);
         if tok == Token::Eof {
             break;
+        }
+    }
+    {
+        let source_lock = source.lock().unwrap();
+        for error in lexer.get_errors().iter() {
+            let file_path = if let Some(file) = error.span.0 {
+                source_lock.get_path(file).to_str().unwrap().to_owned()
+            } else {
+                "<unknown>".to_owned()
+            };
+            eprintln!("ERROR: {}:{}:{}: {}", file_path, error.span.1.line, error.span.1.column, error.message);
         }
     }
 }


### PR DESCRIPTION
As suggested in https://github.com/calixteman/rust-cpp-parser/pull/5#issuecomment-622993852

Originally created for parsing errors (allows you to do `error!` instead of `unreachable!`)